### PR TITLE
Added support of four more AWS regions for AMIs

### DIFF
--- a/service/aws/service.template
+++ b/service/aws/service.template
@@ -7,6 +7,18 @@
             },
             "us-west-1": {
                 "AMI": "ami-af4333cf"
+            },
+            "us-west-2": {
+                "AMI": "ami-d2c924b2"
+            },
+            "eu-central-1": {
+                "AMI": "ami-9bf712f4"
+            },
+            "us-east-1": {
+                "AMI": "ami-6d1c2007"
+            },
+            "ap-southeast-2": {
+                "AMI": "ami-fedafc9d"
             }
         }
     },
@@ -21,7 +33,7 @@
             }
         },
         "EC2InstanceID" : {
-            "Description": "EC2Instance ID",  
+            "Description": "EC2Instance ID",
             "Value" : { "Ref" : "EC2Instance" }
         }
     },
@@ -202,7 +214,7 @@
                     "until [[ $(curl -I -s http://$LOCAL_IPv4|head -n 1|cut -d$' ' -f2) == 301 ]]; do echo \"Chef still not available, sleeping for 5s\"; sleep 5; done\n",
                     "cfn-signal -e $? -r \"Stack setup complete\" '", { "Ref" : "ControllerHandle" }, "'\n"
                   ]
-                ]   
+                ]
                 }
                 }
             },


### PR DESCRIPTION
When i tried to deploy Chef extension at us-east-1 region, i failed, because of:

```
A client error (ValidationError) occurred when calling the CreateStack operation: Template error: Unable to get mapping for RegionMap::us-east-1::AMI
```

Now we would have support:
- eu-west-1
- us-west-1
- us-west-2
- eu-central-1
- us-east-1
- ap-southeast-2

Mapping copied from ADOP SWARM template
