### PR TITLE
Remove SSL configuration

### DIFF
--- a/service/aws/ec2-extension.conf
+++ b/service/aws/ec2-extension.conf
@@ -1,16 +1,13 @@
 server{
   listen 80;
-  listen 443 ssl;
 
   server_name ~^###EC2_SERVICE_NAME###\.*;
 
   access_log  /var/log/nginx/access.log logstash;
-  ssl_certificate         /etc/nginx/ssl/cert.crt;
-  ssl_certificate_key    /etc/nginx/ssl/cert.key;
 
   proxy_set_header host $host;
 
   location /{
-    proxy_pass  https://###EC2_HOST_IP###/;
+    proxy_pass  http://###EC2_HOST_IP###/;
   }
 }


### PR DESCRIPTION
removed path to SSL certs and modified the location proxy_pass param from https to http.
this is due to the fact that Accenture/adop-nginx#23 has removed the self-signed certs.